### PR TITLE
Fix typo in the name of the plugin

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "memes",
-    "name": "Memese",
+    "name": "Memes",
     "description": "Gives you the ability to quickly create and post memes via a /meme slash command.",
     "version": "1.1.0",
     "min_server_version": "5.2.0",


### PR DESCRIPTION
Typo in `config.json` causes the plugin to appear with the name "Memese" in the UI. This change should fix that so it says "Memes" instead.