### PR TITLE
Use SiteURL to build image path

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -116,15 +116,12 @@ func (p *Plugin) OnActivate() error {
 }
 
 func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Request) {
-	if r.Header.Get("Mattermost-User-Id") == "" {
-		http.Error(w, "please log in", http.StatusForbidden)
-		return
-	}
-
 	p.router.ServeHTTP(w, r)
 }
 
 func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
+	siteURL := *p.API.GetConfig().ServiceSettings.SiteURL
+
 	input := strings.TrimSpace(strings.TrimPrefix(args.Command, "/meme"))
 
 	if input == "" || input == "help" {
@@ -147,7 +144,7 @@ If your meme doesn't have well-defined phrasing or you want more control, you ca
 
 In either case...
 
-![brace-yourself](/plugins/memes/templates/brace-yourselves.jpg?text=brace+yourself.&text=memes+are+coming.)
+![brace-yourself](` + siteURL + `/plugins/memes/templates/brace-yourselves.jpg?text=brace+yourself.&text=memes+are+coming.)
 
 Available memes: ` + strings.Join(availableMemes, ", "),
 		}, nil
@@ -168,10 +165,11 @@ Available memes: ` + strings.Join(availableMemes, ", "),
 		queryString += "text=" + url.QueryEscape(t)
 	}
 
-	return &model.CommandResponse{
+	resp := &model.CommandResponse{
 		ResponseType: model.COMMAND_RESPONSE_TYPE_IN_CHANNEL,
-		Text:         "![" + template.Name + "](/plugins/memes/templates/" + template.Name + ".jpg" + queryString + ")",
-	}, nil
+		Text:         "![" + template.Name + "](" + siteURL + "/plugins/memes/templates/" + template.Name + ".jpg" + queryString + ")",
+	}
+	return resp, nil
 }
 
 func main() {


### PR DESCRIPTION
#### Summary
If the image proxy is enabled, relative links to images can't be resolved. Until https://mattermost.atlassian.net/browse/MM-23185 is resolved, the plugin should just use an absolute URL instead.

I also remove the authentication part, because the image proxy has to take a request and doesn't have the secession token. Given that there is no discovery of images, I don't think this is an issue.

#### Ticket Link
Fixes #9 
Fixes #11 
