### PR TITLE
Use make all as default target

### DIFF
--- a/build/custom.mk
+++ b/build/custom.mk
@@ -1,5 +1,7 @@
 # Include custom targets and environment variables here
 
+.DEFAULT_GOAL := all
+
 memelibrary: $(shell find server/memelibrary/assets)
 	env GO111MODULE=off $(GO) get github.com/jteeuwen/go-bindata/...
 	$(GOPATH)/bin/go-bindata -o server/memelibrary/assets.go -pkg memelibrary -prefix server/memelibrary/assets/ -ignore '(^|/)\..*' server/memelibrary/assets/...


### PR DESCRIPTION
#### Summary
This ensures that running `make` executes `make all` instead of `make memelibrary`.

#### Ticket Link
https://github.com/mattermost/mattermost-plugin-memes/pull/28#issuecomment-657957271