### PR TITLE
[GH-33] fixes nil pointer panic if SiteURL is not set

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -111,6 +111,9 @@ type Plugin struct {
 }
 
 func (p *Plugin) OnActivate() error {
+	if p.API.GetConfig().ServiceSettings.SiteURL == nil {
+		p.API.LogError("SiteURL must be set. Some features will operate incorrectly if the SiteURL is not set. See documentation for details: http://about.mattermost.com/default-site-url")
+	}
 	p.router = mux.NewRouter()
 	p.router.HandleFunc("/templates/{name}.jpg", serveTemplateJPEG).Methods("GET")
 	if err := p.API.RegisterCommand(createMemesCommand()); err != nil {
@@ -152,7 +155,11 @@ func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 }
 
 func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
-	siteURL := *p.API.GetConfig().ServiceSettings.SiteURL
+	siteURL := ""
+	ptr := p.API.GetConfig().ServiceSettings.SiteURL
+	if ptr != nil {
+		siteURL = *ptr
+	}
 
 	input := strings.TrimSpace(strings.TrimPrefix(args.Command, "/meme"))
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -154,12 +154,17 @@ func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 	p.router.ServeHTTP(w, r)
 }
 
-func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
+func (p *Plugin) GetSiteURL() string {
 	siteURL := ""
 	ptr := p.API.GetConfig().ServiceSettings.SiteURL
 	if ptr != nil {
 		siteURL = *ptr
 	}
+	return siteURL
+}
+
+func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
+	siteURL := p.GetSiteURL()
 
 	input := strings.TrimSpace(strings.TrimPrefix(args.Command, "/meme"))
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -154,15 +154,6 @@ func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 	p.router.ServeHTTP(w, r)
 }
 
-func (p *Plugin) GetSiteURL() string {
-	siteURL := ""
-	ptr := p.API.GetConfig().ServiceSettings.SiteURL
-	if ptr != nil {
-		siteURL = *ptr
-	}
-	return siteURL
-}
-
 func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
 	siteURL := p.GetSiteURL()
 
@@ -210,6 +201,15 @@ Available memes: ` + strings.Join(availableMemes, ", "),
 		Text:         "![" + template.Name + "](" + siteURL + "/plugins/memes/templates/" + template.Name + ".jpg" + queryString + ")",
 	}
 	return resp, nil
+}
+
+func (p *Plugin) GetSiteURL() string {
+	siteURL := ""
+	ptr := p.API.GetConfig().ServiceSettings.SiteURL
+	if ptr != nil {
+		siteURL = *ptr
+	}
+	return siteURL
 }
 
 func main() {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Adds a check if SiteURL is set or not during `OnActivate` and logs an error. Also adds a check during `ExecuteCommand`, so that it uses an empty string instead of trying to dereference the nil pointer. Using the empty string made the plugin work fine even when the SiteURL was not set on my dev server.
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes: [GH-33](https://github.com/mattermost/mattermost-plugin-memes/issues/33)

